### PR TITLE
Adicionar efeitos visuais aos cards e fade-in no container

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,0 +1,166 @@
+body{
+    cursor: url("../assets/cursor/yugicursor.png"), default;
+}
+
+button, 
+a,
+img:hover,
+button:hover,
+a:hover{
+    cursor: url("../assets/cursor/yamiyugicursorGLOW.png"), auto;
+}
+
+.bg-video{
+    position:absolute;
+    z-index: -2;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+}
+
+.bg-video .video{
+    height: 100vh;
+}
+
+.bg-video::after{
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: 100vw;
+    background:
+    linear-gradient(
+        90deg,
+        rgba(0,0,0,0.8)0%,
+        rgba(0,0,0,0.5)50%,
+        rgba(0,0,0,0.8)100%
+    );
+}
+
+.container{
+    position: relative;
+    z-index: 3;
+    display: flex;
+    height: 100vh;
+    align-items: flex-start;
+    opacity: 0;
+    animation: fadeInContainer 1s forwards;
+}
+
+@keyframes fadeInContainer {
+    to { opacity: 1; }
+}
+
+.container__left{
+    display: flex;
+    width: 35%;
+    min-width: 300px;
+    flex-direction: column;
+    justify-content: space-around;
+    align-items: center;
+}
+
+.score_box{
+    background-color: #fff;
+    padding: 30px;
+}
+
+.frame{
+    border: 3px solid #000;
+    border-radius: 5px;
+}
+
+.card_details{
+    background-color: #fff;
+    border: 3px solid #000;
+    border-radius: 5px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    height: 6rem;
+    width: 100%;
+}
+
+#card-name{
+    font-size: 0.8rem;
+}
+
+#card-type{
+    font-size: 1rem;
+}
+
+.container__right{
+   width: 65%; 
+   margin-left: 2rem;
+   display: flex;
+   flex-direction: column;
+   height: 100vh;
+}
+
+.card-box__container{
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 0.5rem;
+}
+
+.card-versus__container{
+    display: flex;
+    flex-direction: column;
+    padding-top: 0.1rem;
+    height: 300px;
+    justify-items: center;
+    align-items: center;
+    align-content: center;
+}
+
+.versus-top, .vesus-bottom{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.vesus-bottom{
+  margin-top: 1rem;  
+}
+
+#next-duel{
+    display: none;
+}
+
+.card-box__container{
+    height: 9rem;
+    width: 100vw;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-around;
+    margin-top: 2rem;
+}
+
+.card-infield{
+    height: 11.2rem;
+    width: 8rem;
+    border-radius: 8px;
+    opacity: 0;
+    animation: fadeInCard 0.8s forwards;
+}
+
+@keyframes fadeInCard {
+    to { opacity: 1; }
+}
+
+.card{
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover{
+    transform: scale(1.25);
+    box-shadow: 0 0 20px 5px rgba(255,255,0,0.7);
+}


### PR DESCRIPTION
Adicionei melhorias visuais ao jogo de cartas Yu-Gi-Oh!:

Efeito de glow e sombra nos cards ao passar o mouse.
Aumento de escala suave nos hovers.
Fade-in na entrada dos cards e do container principal.
Gradiente de fundo ajustado para melhor visibilidade da lateral.
Essas alterações são puramente visuais e não afetam a lógica do jogo.